### PR TITLE
Fix __hasClass method for correctly validating

### DIFF
--- a/src/tFormer.src.js
+++ b/src/tFormer.src.js
@@ -1627,7 +1627,8 @@
 	 * @returns {boolean}
 	 */
 	var __hasClass = function ( element, class_name ) {
-		return !!(( ~element.className.indexOf( class_name ) ));
+		class_name = " " + class_name + " ";
+		return !!(( ~(" " + element.className + " ").indexOf( class_name ) ));
 	};
 
 


### PR DESCRIPTION
Previous validate return true even when element.className="someclass" and class_name="some".
I used concatenation with whitespace instead of RegExp specifically cuz RegExp work a little slower (peeped in jq ;)
