### PR TITLE
Fixed "name" attribute collision

### DIFF
--- a/src/tFormer.src.js
+++ b/src/tFormer.src.js
@@ -541,7 +541,7 @@
 	 * @param {Array} params
 	 */
 	tFormer_proto.execute = function ( func_name, this_el, params ) {
-		var func = this.get( func_name, (this_el.name || null) );
+		var func = this.get( func_name, (this_el.getAttribute(name) || null) );
 		if ( typeof func == 'function' ) {
 			return func.apply( this_el, (params || []) );
 		}


### PR DESCRIPTION
Form submitting fails when there is an element with `name="name"` in the form:

``` html
<form action="#" name="form">
  <input type="text" name="name">
  <input type="submit" value="Submit">
</form>
```

Instead of passing the `name` attribute of the `form` to the `get` function, the whole element string is passed (e.g. `<input type="text" name="name">` instead of `form`).
